### PR TITLE
Switched to a server side cursor

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -33,11 +33,11 @@ api.add_middleware(
 )
 
 @api.on_event("startup")
-def startup_event():
+async def startup_event():
     """On the startup of the api, instantiate the connection with the database."""
     global pool
     try:
-        pool = establish_connection()
+        pool = await establish_connection()
     except psycopg.OperationalError:
         print("ERROR: Could not connect to the database server")
 

--- a/src/database/connection.py
+++ b/src/database/connection.py
@@ -1,10 +1,11 @@
-import psycopg
 from psycopg_pool import AsyncConnectionPool
 
 from dotenv import load_dotenv
 
 load_dotenv()
 
-def establish_connection():
+async def establish_connection():
     """Return the connection to the server"""
-    return AsyncConnectionPool()
+    pool = AsyncConnectionPool()
+    await pool.wait()
+    return pool

--- a/src/database/queryDB.py
+++ b/src/database/queryDB.py
@@ -1,16 +1,10 @@
-import psycopg
-from src.database.connection import establish_connection
+SERVER_SIDE_CURSOR_LIMIT = 1000
+CLIENT_SIDE_CURSOR_LIMIT = SERVER_SIDE_CURSOR_LIMIT
 
-async def queryDB(pool, query) -> any:
-    try:
-        async with pool.connection() as aconn:
-            async with aconn.cursor() as cur:
-                await cur.execute(query[0], query[1])
-                return await cur.fetchall()
-    except Exception as e:
-        print("Error: ", e)
-        try:
-            pool = establish_connection()
-            await queryDB(pool, query)
-        except psycopg.OperationalError:
-            print("ERROR: Could not connect to the database server")
+async def queryDB(pool, query, tries = 0) -> any:
+    await pool.check() # Discards broken connections. Increases latency based on the number of connections in the pool
+    async with pool.connection() as aconn:
+        async with aconn.cursor("v360API-ssc") as acur: # Creates a server side cursor on the database
+            acur.itersize = SERVER_SIDE_CURSOR_LIMIT
+            await acur.execute(query[0], query[1])
+            return await acur.fetchall()


### PR DESCRIPTION
Instead of psycopg managing the cursor, now the database server does so. The cursor only looks at {itersize} number of rows at a time. 